### PR TITLE
mozilla submission warning patch

### DIFF
--- a/content.js
+++ b/content.js
@@ -220,7 +220,7 @@ style.innerHTML = `
 	}
 
 	.aws-ce-mask:hover {
-		content:url(${comedy});
+		filter: grayscale(100%) brightness(50%) sepia(100%)  saturate(700%) contrast(1);
 	}
 
 	#awsconsoleextensionrole-panel {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "aws-console-extension",
-	"version": "0.3.0",
+	"version": "0.3.1",
 
 	"author": "ian.collar@secretescapes.com",
 


### PR DESCRIPTION
>  **Unsafe assignment to innerHTML**
> 
> Warning: Due to both security and performance concerns, this may not be set using dynamic values which have not been adequately sanitized. This can lead to security issues or fairly serious performance degradation.

Fix for Mozzilla submissin warning.