### PR TITLE
Add switch links to options page

### DIFF
--- a/content.js
+++ b/content.js
@@ -234,6 +234,15 @@ style.innerHTML = `
 		padding-bottom: 20px;
 		min-height: 40px;
 	}
+
+	.awsce-globalNav {
+		color: #FFFFFF;
+		display: inline-flex;
+		padding: 9px;
+		align-items: center;
+		flex-shrink: 0;
+		justify-content: center;
+	}
 `
 
 document.getElementsByTagName('head')[0].appendChild(style);
@@ -247,10 +256,9 @@ icon.addEventListener('click', togglePanel, false)
 icon.classList.add("aws-ce-mask")
 
 var iconDiv = document.createElement("div")
-iconDiv.classList.add("globalNav-034")
-iconDiv.classList.add("globalNav-0399")
-iconDiv.classList.add("globalNav-031")
-iconDiv.classList.add("globalNav-032")
+iconDiv.classList.add("globalNav-0385")
+iconDiv.classList.add("awsce-globalNav")
+iconDiv.classList.add("globalNav-035")
 
 
 var panel = document.createElement("div")
@@ -261,6 +269,8 @@ flex.style.cssText = `
 	display: flex;
 	width: 100%;
 	flex-wrap: wrap;
+	padding-left: 20px;
+	padding-right: 20px;
 `
 var optionsButton = document.createElement("input")
 optionsButton.type = "button"

--- a/content.js
+++ b/content.js
@@ -31,7 +31,7 @@ function recentRoleWarning() {
 	filtersDiv.innerHTML = ''
 
 	var warning = document.createElement("div")
-	warning.textContent = "There must be at least one item in the Role History in order for this functionality to work"
+	warning.textContent = "There are not items in your Role History, please go to Options and click a switch icon to manually switch to enable this functionality."
 	warning.style.cssText = `
 		font-family: "Amazon Ember", "Helvetica Neue", Roboto, Arial, sans-serif;
 		font-size: 15px;

--- a/options.css
+++ b/options.css
@@ -8,7 +8,7 @@ body {
 	color: white;
 	text-align: left;
 	background-color: #232f3e;
-	width: 500px;
+	width: 535px;
 }
 
 h2 {
@@ -125,4 +125,9 @@ input[disabled][name="description"] {
 	font-size: 14px;
 	font-weight: bold;
 	margin-right: 10px;
+}
+
+.switcher {
+	color: #ff8c00;
+	text-decoration: none;
 }

--- a/options.js
+++ b/options.js
@@ -133,6 +133,11 @@ function addRoleRow(groupDiv, role = {}, before) {
 	roleButtonDelete.className = 'deleteButton'
 	roleButtonDelete.addEventListener('click', deleteDiv, false)
 
+	var switcher = document.createElement('a')
+	switcher.name = 'switcher'
+	switcher.className = "switcher"
+	switcher.textContent = "⇄"
+
 	if (JSON.stringify(role) === '{}') {
 		groupDiv.insertBefore(roleDiv, before)
 		roleButtonDelete.style.display = "inline-block"
@@ -150,6 +155,10 @@ function addRoleRow(groupDiv, role = {}, before) {
 
 		inputColor.value = role.color
 		inputColor.disabled = "disabled"
+
+		var title = `${role.role}@${groupDiv.name}-${role.description}`.replace(/-*\s*$/, '')
+		switcher.href = `https://signin.aws.amazon.com/switchrole?roleName=${role.role}&account=${role.account}&displayName=${title}`
+		switcher.title = `Switch to: ${title}`
 	}
 
 	roleDiv.appendChild(inputAccount)
@@ -157,6 +166,7 @@ function addRoleRow(groupDiv, role = {}, before) {
 	roleDiv.appendChild(inputDescription)
 	roleDiv.appendChild(inputColor)
 	roleDiv.appendChild(roleButtonDelete)
+	roleDiv.appendChild(switcher)
 	roleDiv.appendChild(document.createElement('br'))
 }
 
@@ -193,6 +203,7 @@ function addGroupRow(div, groupName = '', before) {
 
 	var groupDiv = document.createElement('div')
 	groupDiv.className = 'group'
+	groupDiv.name = groupName
 
 	groupDiv.appendChild(document.createElement('br'))
 
@@ -262,6 +273,9 @@ function handleEdit() {
 	})
 	document.querySelectorAll('input[type=text]').forEach(item => {
 		item.disabled = null
+	})
+	document.querySelectorAll('a[class=switcher]').forEach(item => {
+		item.style.display = 'none'
 	})
 
 	regions.style.display = "none"


### PR DESCRIPTION
Adds a link to the roles in the options page. This is useful for either:
- first time running the extension and getting a role in the cache for the others to work from.
- being able to share links with others via copy/paste.